### PR TITLE
Individuals namespace draft

### DIFF
--- a/src/gsgp/individual.clj
+++ b/src/gsgp/individual.clj
@@ -1,0 +1,10 @@
+(ns gsgp.individual
+  (:require [gsgp.language.core :refer [program->value]]))
+
+
+(defrecord Individual [program phenotype fitness])
+
+
+(defn program->phenotype
+  [program input-set]
+  (mapv #(program->value program %) input-set))


### PR DESCRIPTION
Added the individuals namespace, closes #2. 

I think the next step should be adding genetic operators definition to the language macro. Genetic operators should take as arguments individuals, which have already computed their phenotype and fitness, and produce a new individual with all data computed as well.
