### PR TITLE
Added genetic operator to language definitions (draft)

### DIFF
--- a/src/gsgp/core.clj
+++ b/src/gsgp/core.clj
@@ -8,19 +8,23 @@
    (var   (input (rand-int 2)))]
 
   [(plus  [e1 e2] (funcall + e1 e2))
-   (times [e1 e2] (funcall * e1 e2))])
+   (minus [e1 e2] (funcall - e1 e2))
+   (times [e1 e2] (funcall * e1 e2))]
 
-(deflang bool
-  [(const (constant (rand-nth [true false])))
-   (var   (input (rand-int 2)))]
+  (mutation [t]
+    [t1 (rand-program arith 2 false)
+     t2 (rand-program arith 2 false)
+     s  0.0001]
+    (plus t (times (constant s) (minus t1 t2))))
 
-  [(not [e1]    (funcall not e1))
-   (and [e1 e2] (funcall (macroexpand 'and) e1 e2))
-   (or  [e1 e2] (funcall (macroexpand 'or)  e1 e2))])
+  (crossover [t1 t2]
+    [a (rand)
+     b (- 1 a)]
+    (plus (times (constant a) t1) (times (constant b) t2))))
 
 
 (defn teste
   []
-  (let [p (rand-program bool 3 false)
-        inputs [true false false]]
+  (let [p (rand-program arith 3 false)
+        inputs [1 2 3]]
     (program->value p inputs)))


### PR DESCRIPTION
Added language operator in language definitions, closes #6.

So, this should not be the final version for genetic operator definitions. Several things may be improved like:
- Generation of random programs shouldn't need the language as arguments (?)
- Added macros (`bind-lang-ref` and `parse-genetic-operator`) could have their codes drastically improved
