### PR TITLE
Implemented simple txt exporter

### DIFF
--- a/src/gsgp/data.clj
+++ b/src/gsgp/data.clj
@@ -1,8 +1,14 @@
 (ns gsgp.data
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+   :require [clojure.string  :as string]))
 
 
 (defn load-txt
   [file-name]
-  (with-open [rdr (io/reader file-name)]
-    (mapv #(read-string (str "[" % "]")) (line-seq rdr))))
+  (with-open [r (io/reader file-name)]
+    (mapv #(read-string (str "[" % "]")) (line-seq r))))
+
+(defn save-txt
+  [file-name data-set]
+  (with-open [w (io/writer file-name)]
+    (.write w (string/join "\n" (mapv #(string/join " " %) data-set)))))


### PR DESCRIPTION
Implemented txt exporter which exports a dataset matrix to a whitespace separated file.

Ex:

``` clojure
(save-txt filename [[0 1] [2 3]])
```

outputs a file

```
0 1
2 3
```
